### PR TITLE
Tg#1273

### DIFF
--- a/web/.jenkins-import/import.sh
+++ b/web/.jenkins-import/import.sh
@@ -29,10 +29,12 @@ dc up -d database
 sleep 50
 
 # load latest bag into database
-echo "Load latest verblijfsobjecten en nummeraanduidingen in handelsregister database"
+echo "Load latest verblijfsobjecten, ligplaatsen, standplaatsen and nummeraanduidingen in handelsregister database"
 
 # dc exec -T database update-db.sh atlas
 dc exec -T database update-table.sh bag bag_verblijfsobject public handelsregister
+dc exec -T database update-table.sh bag bag_ligplaats public handelsregister
+dc exec -T database update-table.sh bag bag_standplaats public handelsregister
 dc exec -T database update-table.sh bag bag_nummeraanduiding public handelsregister
 
 echo "create hr api database / reset elastic index"

--- a/web/handelsregister/datasets/build_hr_data.py
+++ b/web/handelsregister/datasets/build_hr_data.py
@@ -110,9 +110,32 @@ def fill_location_with_bag():
     the fields get updated with bag data.
 
     """
+    select = """
+UPDATE hr_locatie loc
+   SET geometrie = bag.geometrie,
+       huisnummer = bag.huisnummer,
+       huisletter = bag.huisletter,
+       huisnummertoevoeging = bag.huisnummer_toevoeging,
+       straatnaam = bag._openbare_ruimte_naam,
+       postcode = bag.postcode
+  FROM (SELECT v.id,
+               v.landelijk_id,
+               n.huisnummer,
+               n.huisletter,
+               n.huisnummer_toevoeging,
+               n._openbare_ruimte_naam,
+               n.postcode,
+               v.geometrie
+          FROM bag_nummeraanduiding n
+    INNER JOIN bag_{type} v
+            ON n.{bagtype}_id = v.id
+         WHERE n.hoofdadres) bag
+ WHERE bag.landelijk_id = loc.bag_vbid OR bag.landelijk_id = loc.bag_numid
+    """
     with db.connection.cursor() as cursor:
         log.info("VUL geo tabel locaties met bag geometrie")
-        _update_location_table_with_bag(cursor)
+        for bagtype in ('verblijfsobject', 'ligplaats', 'standplaats'):
+            cursor.execute(select.format(bagtype=bagtype))
 
 
 def fill_geo_table():
@@ -617,29 +640,6 @@ SET eigenaar_mks_id = m.prsid
 FROM kvkmacm00 m
 WHERE m.macid = hrm.id AND NOT EXISTS (
     SELECT * FROM hr_persoon WHERE id = m.prsid)
-    """)
-
-
-def _update_location_table_with_bag(cursor):
-    cursor.execute("""
-UPDATE hr_locatie loc
-    SET geometrie = bag.geometrie,
-        huisnummer = bag.huisnummer,
-        huisletter = bag.huisletter,
-        huisnummertoevoeging = bag.huisnummer_toevoeging,
-        straatnaam = bag._openbare_ruimte_naam,
-        postcode = bag.postcode
-FROM (select v.id,
-      v.landelijk_id,
-      n.huisnummer,
-      n.huisletter,
-      n.huisnummer_toevoeging,
-      n._openbare_ruimte_naam,
-      n.postcode,
-      v.geometrie
-      FROM bag_nummeraanduiding n, bag_verblijfsobject v
-      WHERE n.verblijfsobject_id = v.id AND n.hoofdadres) bag
-WHERE bag.landelijk_id = loc.bag_vbid OR bag.landelijk_id = loc.bag_numid
     """)
 
 

--- a/web/handelsregister/datasets/build_hr_data.py
+++ b/web/handelsregister/datasets/build_hr_data.py
@@ -127,7 +127,7 @@ UPDATE hr_locatie loc
                n.postcode,
                v.geometrie
           FROM bag_nummeraanduiding n
-    INNER JOIN bag_{type} v
+    INNER JOIN bag_{bagtype} v
             ON n.{bagtype}_id = v.id
          WHERE n.hoofdadres) bag
  WHERE bag.landelijk_id = loc.bag_vbid OR bag.landelijk_id = loc.bag_numid

--- a/web/handelsregister/datasets/build_hr_data.py
+++ b/web/handelsregister/datasets/build_hr_data.py
@@ -125,7 +125,7 @@ UPDATE hr_locatie loc
                n.huisnummer_toevoeging,
                n._openbare_ruimte_naam,
                n.postcode,
-               v.geometrie
+               ST_Centroid(v.geometrie) as geometrie
           FROM bag_nummeraanduiding n
     INNER JOIN bag_{bagtype} v
             ON n.{bagtype}_id = v.id


### PR DESCRIPTION
Dit PR:

* laadt naast BAG verblijfsobjecten ook ligplaatsen en standplaatsen in de `hr_locatie` tabel
* matched HR vestigingen naast BAG verblijfsobjecten ook met ligplaatsen en standplaatsen

Let op: ik weet niet precies waarvoor de geometrie in de `hr_locatie` tabel gebruikt wordt maar de geometrie van stand- en ligplaatsen, in de BAG polygonen, importeer ik daarin als punten. Op het eerste gezicht heeft dat geen gevolgen.